### PR TITLE
modules/openssl: remove libgcc path hack

### DIFF
--- a/modules/openssl
+++ b/modules/openssl
@@ -7,15 +7,11 @@ openssl_tar := openssl-$(openssl_version).tar.gz
 openssl_url := https://www.openssl.org/source/$(openssl_tar)
 openssl_hash := 6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e
 
-# hack to provide path to libgcc
-LIBGCC_DIR := $(dir $(shell $(heads_cc) -print-libgcc-file-name))
-
 # The only optional algorithm that's enabled is SM3.  tpm2-tss uses SHA, AES,
 # and SM3.
 openssl_configure := \
 	$(CROSS_TOOLS) \
 	CFLAGS="-Os" \
-	LDFLAGS="-L$(LIBGCC_DIR)" \
 	./Configure \
 		--prefix="/" \
 		no-tests \


### PR DESCRIPTION
Passing the path to libgcc in LDFLAGS appears to no longer be needed. Removing this fixes compilation on a freshly cloned repo.

Cherry pick of https://github.com/linuxboot/heads/pull/1614