### PR TITLE
Cbfs ext bios window

### DIFF
--- a/boards/msi_z690a_ddr4/msi_z690a_ddr4.config
+++ b/boards/msi_z690a_ddr4/msi_z690a_ddr4.config
@@ -43,7 +43,9 @@ export CONFIG_PRIMARY_KEY_TYPE=ecc
 CONFIG_TPM2_TSS=y
 CONFIG_OPENSSL=y
 
-
 export CONFIG_BOOT_DEV="/dev/nvme0n1"
 export CONFIG_BOARD_NAME="MSI PRO Z690-A DDR4"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
+
+# Workaround to access > 16MiB BIOS region on ADL+
+export CONFIG_CBFS_VIA_FLASHROM=y

--- a/boards/msi_z690a_ddr5/msi_z690a_ddr5.config
+++ b/boards/msi_z690a_ddr5/msi_z690a_ddr5.config
@@ -43,7 +43,9 @@ export CONFIG_PRIMARY_KEY_TYPE=ecc
 CONFIG_TPM2_TSS=y
 CONFIG_OPENSSL=y
 
-
 export CONFIG_BOOT_DEV="/dev/nvme0n1"
 export CONFIG_BOARD_NAME="MSI PRO Z690-A"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
+
+# Workaround to access > 16MiB BIOS region on ADL+
+export CONFIG_CBFS_VIA_FLASHROM=y

--- a/boards/msi_z790p_ddr4/msi_z790p_ddr4.config
+++ b/boards/msi_z790p_ddr4/msi_z790p_ddr4.config
@@ -43,7 +43,9 @@ export CONFIG_PRIMARY_KEY_TYPE=ecc
 CONFIG_TPM2_TSS=y
 CONFIG_OPENSSL=y
 
-
 export CONFIG_BOOT_DEV="/dev/nvme0n1"
 export CONFIG_BOARD_NAME="MSI PRO Z790-P DDR4"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
+
+# Workaround to access > 16MiB BIOS region on ADL+
+export CONFIG_CBFS_VIA_FLASHROM=y

--- a/boards/msi_z790p_ddr5/msi_z790p_ddr5.config
+++ b/boards/msi_z790p_ddr5/msi_z790p_ddr5.config
@@ -43,7 +43,9 @@ export CONFIG_PRIMARY_KEY_TYPE=ecc
 CONFIG_TPM2_TSS=y
 CONFIG_OPENSSL=y
 
-
 export CONFIG_BOOT_DEV="/dev/nvme0n1"
 export CONFIG_BOARD_NAME="MSI PRO Z790-P"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
+
+# Workaround to access > 16MiB BIOS region on ADL+
+export CONFIG_CBFS_VIA_FLASHROM=y

--- a/initrd/bin/cbfs-init
+++ b/initrd/bin/cbfs-init
@@ -11,8 +11,9 @@ fi
 
 if [ "$CONFIG_CBFS_VIA_FLASHROM" = "y" ]; then
 	# Use flashrom directly, because we don't have /tmp/config with params for flash.sh yet
-	/bin/flashrom -p internal --fmap -i COREBOOT -i FMAP -r /tmp/cbfs-init.rom > /dev/null 2>&1
-	CBFS_ARG=" -o /tmp/cbfs-init.rom"
+	/bin/flashrom -p internal --fmap -i COREBOOT -i FMAP -r /tmp/cbfs-init.rom > /dev/null 2>&1 \
+		&& CBFS_ARG=" -o /tmp/cbfs-init.rom" \
+		|| echo "Failed reading Heads configuration from flash! Some features may not be available."
 fi
 
 # Load individual files

--- a/initrd/bin/cbfs-init
+++ b/initrd/bin/cbfs-init
@@ -9,8 +9,14 @@ if [ -z "$CONFIG_PCR" ]; then
 	CONFIG_PCR=7
 fi
 
+if [ "$CONFIG_CBFS_VIA_FLASHROM" = "y" ]; then
+	# Use flashrom directly, because we don't have /tmp/config with params for flash.sh yet
+	/bin/flashrom -p internal --fmap -i COREBOOT -i FMAP -r /tmp/cbfs-init.rom > /dev/null 2>&1
+	CBFS_ARG=" -o /tmp/cbfs-init.rom"
+fi
+
 # Load individual files
-cbfsfiles=`cbfs -t 50 -l 2>/dev/null | grep "^heads/initrd/"`
+cbfsfiles=`cbfs -t 50 -l $CBFS_ARG 2>/dev/null | grep "^heads/initrd/"`
 
 for cbfsname in `echo $cbfsfiles`; do
 	filename=${cbfsname:12}
@@ -18,7 +24,7 @@ for cbfsname in `echo $cbfsfiles`; do
 		echo "Loading $filename from CBFS"
 		mkdir -p `dirname $filename` \
 		|| die "$filename: mkdir failed"
-		cbfs -t 50 -r $cbfsname > "$filename" \
+		cbfs -t 50 $CBFS_ARG -r $cbfsname > "$filename" \
 		|| die "$filename: cbfs file read failed"
 		if [ "$CONFIG_TPM" = "y" ]; then
 			TMPFILE=/tmp/cbfs.$$


### PR DESCRIPTION
Dump BIOS contents via flashrom instead of attempting to access the BIOS mapping directly, as the BIOS window is only 16MiB and our BIOS region is 28MiB.

Ideally we'd add support for accessing the extended BIOS window to flashtools, but this will do as a workaround for now.