### PR TITLE
Update preserve_rom function to check if /tmp/cbfs-init.rom should be used.

### DIFF
--- a/initrd/etc/ash_functions
+++ b/initrd/etc/ash_functions
@@ -38,14 +38,19 @@ TRACE() {
 
 preserve_rom() {
 	TRACE "Under /etc/ash_functions:preserve_rom"
+	if [ "$CONFIG_CBFS_VIA_FLASHROM" = "y" ]; then
+		CBFS_ARG=" -o /tmp/cbfs-init.rom"
+	else
+		CBFS_ARG=""
+	fi
 	new_rom="$1"
-	old_files=`cbfs -t 50 -l 2>/dev/null | grep "^heads/"`
+	old_files=`cbfs -t 50 -l $CBFS_ARG 2>/dev/null | grep "^heads/"`
 
 	for old_file in `echo $old_files`; do
 		new_file=`cbfs.sh -o $1 -l | grep -x $old_file`
 		if [ -z "$new_file" ]; then
 			echo "+++ Adding $old_file to $1"
-			cbfs -t 50 -r $old_file >/tmp/rom.$$ \
+			cbfs -t 50 $CBFS_ARG -r $old_file >/tmp/rom.$$ \
 			|| die "Failed to read cbfs file from ROM"
 			cbfs.sh -o $1 -a $old_file -f /tmp/rom.$$ \
 			|| die "Failed to write cbfs file to new ROM file"


### PR DESCRIPTION
On the MSI boards, the "internal" CBFS region, which is the default when calling cbfs without arguments, returns no files, or when called with -v, errors:

```
Header delta          : -29261268
Header magic          : ffffffff
Header version        : ffffffff
Header ROM size       : ffffffff
Header boot block size: ffffffff
Header align          : ffffffff
Header offset         : ffffffff
Header arch           : ffffffff
Failed to find valid header
```

This patch is an extension of https://github.com/linuxboot/heads/commit/4d533b36976d1a00d1964449b199e6dad1858a85 changes, which if configured uses flashrom to extract the image of the CBFS there, and here it uses that extracted image to add files to the image which is to be flashed.

This has been tested on my MSI Z790-P DDR4 board.